### PR TITLE
[Feat] Add D+Day Calculator

### DIFF
--- a/liveOn/liveOn/Views/GiftBoxView.swift
+++ b/liveOn/liveOn/Views/GiftBoxView.swift
@@ -59,6 +59,7 @@ struct GiftBoxView: View {
     // MARK: 이름+사귄 디데이 계산 정보
     // TODO: 유저 네임, 사귄날 데이터로 디데이 계산
     var coupleInfo: some View {
+      
         NavigationLink(destination: Text("CoupleInformationView")) {
             HStack(alignment: .center, spacing: 12) {
                 Text("\(currnetUser.nickname)")
@@ -67,10 +68,15 @@ struct GiftBoxView: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 25, height: 25)
                 Text("유진")
-                Text("+ 123")
-                    .fontWeight(.bold)
+                HStack(alignment: .center, spacing: 1) {
+                    Image(systemName: "plus")
+                    Text("\(countDays(from: currnetUser.firstDay!))")
+                        .fontWeight(.semibold)
+                }
+                .foregroundColor(Color("Orange"))
+                
             }
-            .font(.title3)
+            .font(.subheadline)
             .foregroundColor(Color.bodyTextColor)
             .padding(.horizontal, 20)
             .padding(.vertical, 12)
@@ -153,3 +159,8 @@ struct GiftBoxView: View {
 //            .environmentObject(User())
 //    }
 // }
+
+func countDays(from date: Date) -> Int {
+    let calendar = Calendar.current
+    return calendar.dateComponents([.day], from: date, to: Date()).day! + 1
+}


### PR DESCRIPTION
더미데이터이던 +Day 가 실제 입력된 값에서 계산되게 했습니다.

## What is this PR do?
- `GiftBoxView' 상단의 couple Info 부분이 실제 등록한 날짜와 연동되도록 했습니다.
-  오늘-기념일 계산 함수를 만들었습니다.
- UI 약간 수정했습니다.
## TODO
- [ ] 서버쪽에서 DDay까지 계산해서 보내주는 것으로 되어 해당 함수 삭제 후 **서버에서 받아오는 식**으로 구현할 것 같습니다.

## Screenshot
![simulator_screenshot_4EED0109-96F1-4C09-9ED2-DFE0EF585F82](https://user-images.githubusercontent.com/61951603/173712254-7895e1ff-059b-48ce-bb61-69a184b29478.png)
