### PR TITLE
[Feat] Create VoicemailListView

### DIFF
--- a/liveOn/liveOn/Views/Voicemail/VoicemailListAssetView.swift
+++ b/liveOn/liveOn/Views/Voicemail/VoicemailListAssetView.swift
@@ -1,0 +1,89 @@
+//
+//  VoicemailListAssetView.swift
+//  liveOn
+//
+//  Created by Jineeee on 2022/06/16.
+//
+
+import SwiftUI
+import Alamofire
+
+struct Voicemail: Identifiable {
+    let id = UUID()
+    let title: String
+    let createDate: String
+    let whoSent: String
+    let vmBackgroundColor: Color
+    let vmIconImageName: String
+    let soundLength: String
+    
+}
+
+struct mailConstants {
+    static let user1 = "재헌"
+    static let user2 = "유진"
+    static let green = Color(hex: "717339")
+    static let orange = Color(hex: "A6633C")
+}
+
+// 카세트 하나 뷰
+struct VoicemailListAssetView: View {
+    @State var isShowPopUp = false
+    let voiceMail: Voicemail
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .center, spacing: 0) {
+                Rectangle()
+                    .fill(Color(hex: "F2F0F0"))
+                    .frame(width: 10, height: 60, alignment: .center)
+                
+                HStack {
+                    Image(voiceMail.vmIconImageName)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 44, height: 44, alignment: .center)
+                    
+                    // MARK: 정보부분
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(voiceMail.title)
+                            .font(.subheadline)
+                            .fontWeight(.bold)
+                        HStack {
+                            Text(voiceMail.createDate)
+                            Spacer()
+                            Text("from. \(voiceMail.whoSent)")
+                        }
+                    }
+                    .font(.caption)
+                    .opacity(0.9)
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: 60, alignment: .center)
+                    .background(voiceMail.vmBackgroundColor)
+                    .foregroundColor(.white)
+                    
+                    Text(voiceMail.soundLength)
+                        .rotationEffect(.degrees(-90.0))
+                        .font(.caption)
+                        .foregroundColor(.bodyTextColor)
+                    
+                }
+                .background(.thinMaterial)
+                .frame(maxWidth: .infinity, maxHeight: 60, alignment: .center)
+            }
+            Rectangle()
+                .fill(Color(uiColor: .systemGray5))
+                .frame(width: .infinity, height: 4, alignment: .leading)
+        }
+        .border(.thinMaterial, width: 3)
+        .border(.white, width: 2)
+        .border(.thinMaterial, width: 2)
+        .overlay(Rectangle().fill(.regularMaterial).opacity(0.2))
+        
+        .onTapGesture {
+            isShowPopUp.toggle()
+        }
+        .sheet(isPresented: $isShowPopUp ) {
+            Text("dsf")
+        }
+    }
+}

--- a/liveOn/liveOn/Views/Voicemail/VoicemailListView_.swift
+++ b/liveOn/liveOn/Views/Voicemail/VoicemailListView_.swift
@@ -1,0 +1,79 @@
+//
+//  VoicemailListView_.swift
+//  liveOn
+//
+//  Created by Jineeee on 2022/06/16.
+//
+
+import SwiftUI
+
+struct VoicemailListView_: View {
+    var body: some View {
+    
+        if voiceMailDummy.count > 8 {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack {
+                Spacer()
+                VStack(alignment: .trailing, spacing: 16) {
+                    ForEach(voiceMailDummy) { vm in
+                        VoicemailListAssetView(voiceMail: vm)
+                    }
+                    //            }
+                    //            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    //            .background(.blue)
+                }
+                .padding(12)
+                .border(.thinMaterial, width: 1)
+                .background(.regularMaterial)
+                .padding(16)
+               
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle("카세트테이프")
+            .navigationBarTitleDisplayMode(.inline)
+            .background(Color.background)
+        }
+    } else {
+        VStack {
+            Spacer()
+            VStack(alignment: .trailing, spacing: 16) {
+                ForEach(voiceMailDummy) { vm in
+                    VoicemailListAssetView(voiceMail: vm)
+                }
+                //            }
+                //            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                //            .background(.blue)
+            }
+            .padding(12)
+            .border(.thinMaterial, width: 1)
+            .background(.regularMaterial)
+            .padding(16)
+           
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle("카세트테이프")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(Color.background)
+    }
+    
+    }
+}
+
+var voiceMailDummy = [
+    Voicemail(title: "재허나뭐해잉", createDate: "220616", whoSent: mailConstants.user1, vmBackgroundColor: mailConstants.green, vmIconImageName: "flower", soundLength: "00:48"),
+    Voicemail(title: "유지나뭐해잉", createDate: "220314", whoSent: mailConstants.user2, vmBackgroundColor: mailConstants.orange, vmIconImageName: "flower", soundLength: "00:39"),
+    Voicemail(title: "유sdf잉", createDate: "220314", whoSent: mailConstants.user2, vmBackgroundColor: mailConstants.orange, vmIconImageName: "flower", soundLength: "00:39"),
+    Voicemail(title: "유지나뭐fsd잉", createDate: "220314", whoSent: mailConstants.user2, vmBackgroundColor: mailConstants.orange, vmIconImageName: "flower", soundLength: "00:39"),
+    Voicemail(title: "유지나뭐해잉", createDate: "220314", whoSent: mailConstants.user2, vmBackgroundColor: mailConstants.orange, vmIconImageName: "fdsower", soundLength: "00:39"),
+    Voicemail(title: "유지나뭐해잉", createDate: "220314", whoSent: mailConstants.user2, vmBackgroundColor: mailConstants.orange, vmIconImageName: "flower", soundLength: "00:39"),
+    Voicemail(title: "유지나뭐해잉", createDate: "220314", whoSent: mailConstants.user2, vmBackgroundColor: mailConstants.orange, vmIconImageName: "flower", soundLength: "00:39")
+
+]
+
+struct VoicemailListView__Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            VoicemailListView_()
+        }
+    }
+}


### PR DESCRIPTION
## What is this PR do?
- 음성메모를 모아볼 수 있는 voiceMailView 를 생성했습니다.
- 카세트테입 하나의 뷰를 voicemailListAsset 에서 담당, voicemailListView에서 리스트 전체를 그립니다.
- 🕹 아래서부터 쌓이게 하고 싶어서, 8개 이하일 때는 일반 VStack으로 아래에 있게 했고, 초과일 때는 ScrollView 안에서  스크롤이 작동하게 했습니다.

## Need to
- [ ] : 디테일 팝업 뜨게 하기
- [ ] : MVVM 맞게 정리하기?
