### PR TITLE
Feat: 서버로부터 Image 데이터 받아오기

### DIFF
--- a/liveOn/liveOn.xcodeproj/project.pbxproj
+++ b/liveOn/liveOn.xcodeproj/project.pbxproj
@@ -668,7 +668,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"liveOn/Preview Content\"";
-				DEVELOPMENT_TEAM = VHT56LS632;
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -682,7 +682,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com-id.liveOn--explicit-";
+				PRODUCT_BUNDLE_IDENTIFIER = "com-id.liveOdsa";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -697,11 +697,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = liveOn/liveOn.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"liveOn/Preview Content\"";
-				DEVELOPMENT_TEAM = VHT56LS632;
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -715,9 +715,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com-id.liveOn--explicit-";
+				PRODUCT_BUNDLE_IDENTIFIER = sasd;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = Jisu_Jang;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/liveOn/liveOn/Models/ServerCommunication.swift
+++ b/liveOn/liveOn/Models/ServerCommunication.swift
@@ -4,6 +4,7 @@ import Moya
 
 let moyaService = MoyaProvider<ServerCommunications>(plugins: [NetworkLoggerPlugin()])
 var testImageData: ImageTestResponse?
+var loadedImage: ImageGetResponse?
 
 struct GeneralAPI {
     static let baseURL = "http://13.124.90.96:8080"
@@ -16,6 +17,7 @@ enum ServerCommunications {
   
     case login(param: LoginRequest) // 파라미터로 스트럭트가 들어갑니다.
     case imagePost(comment: String, polaroid: UIImage)
+    case imageGet
     case voicemailPost(title: String)
     case getData
 }
@@ -39,6 +41,13 @@ struct ImageTestResponse: Codable {
     let imageName: String
 }
 
+struct ImageGetResponse: Codable {
+    let createdAt: String
+    let giftPolaroidId: Int64
+    let giftPolaroidImage: String
+    let userNickName: String
+}
+
 // http method, URLSession task, header 작성 등을 케이스 분류
 extension ServerCommunications: TargetType, AccessTokenAuthorizable {
     public var baseURL: URL {
@@ -54,6 +63,9 @@ extension ServerCommunications: TargetType, AccessTokenAuthorizable {
         case .imagePost:
             return "api/v1/gifts/polaroids"
             
+        case .imageGet:
+            return "/api/v1/gifts/polaroids/1"
+            
         case .voicemailPost:
             return "/api/v1/gifts/voicemail"
             
@@ -67,7 +79,7 @@ extension ServerCommunications: TargetType, AccessTokenAuthorizable {
         switch self {
         case .login, .imagePost, .voicemailPost:
             return .post
-        case .getData:
+        case .getData, .imageGet:
             return .get
         }
     }
@@ -110,6 +122,9 @@ extension ServerCommunications: TargetType, AccessTokenAuthorizable {
             
             // MARK: get test 요청
         case .getData:
+            return .requestPlain
+            
+        case .imageGet:
             return .requestPlain
         }
     }

--- a/liveOn/liveOn/Views/PictureGift/PhotoCardsView.swift
+++ b/liveOn/liveOn/Views/PictureGift/PhotoCardsView.swift
@@ -10,8 +10,10 @@ import SwiftUI
 struct PhotoCardsView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject var imageModel: ImageViewModel
-    private let columns: [GridItem] = Array(repeating: .init(.flexible()), count: 2)
-    private let temporaryData: [PhotoCardInformation] = [testData1, testData2, testData3, testData4]
+    @State var loadedImage = ImageGetResponse(createdAt: "", giftPolaroidId: 0, giftPolaroidImage: "", userNickName: "")
+    @State private var PhotoGiftDataList: [PhotoGiftData] = []
+    var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 2)
+    var temporaryData: [PhotoCardInformation] = [testData1, testData2, testData3,testData4]
     
     var body: some View {
         ScrollView {
@@ -21,9 +23,21 @@ struct PhotoCardsView: View {
                         .background(Color.white
                             .shadow(color: Color.black.opacity(0.25), radius: 4, x: 0, y: 4))
                         .padding(5)
+                    
+                    ForEach(PhotoGiftDataList, id: \.self) { imageData in
+                        LoadedPhotoCard(PhotoCardDetail: imageData)
+                    }
+                    
+                    AsyncImage(url: URL(string: loadedImage.giftPolaroidImage))
+                        .frame(width: 300, height: 300, alignment: .center)
                 }
             }
             .frame(maxWidth: .infinity)
+        }
+        .task {
+            imageGet()
+            print("이미지 로딩이 수행되었습니다.")
+            PhotoGiftDataList.append(PhotoGiftData(photoURL: loadedImage.giftPolaroidImage, photoComment: loadedImage.userNickName))
         }
         .padding()
         .background(Color.background)
@@ -31,11 +45,7 @@ struct PhotoCardsView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: {
-//                    if imageModel.isSent == true {
-//                        imageModel.isSent == false
-//                    } else {
-                        dismiss()
-//                    }
+                    dismiss()
                 }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 20))
@@ -48,11 +58,31 @@ struct PhotoCardsView: View {
             }
         }
     }
+    func imageGet() {
+        moyaService.request(.imageGet) { response in
+            switch response {
+            case .success(let result):
+                do {
+                    loadedImage = try result.map(ImageGetResponse.self)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                    print("이미지를 디코딩하는데 실패했습니다")
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
 }
 
 struct PhotoCardInformation: Hashable {
     var imageName: String
     var photoText: String
+}
+
+struct PhotoGiftData: Hashable {
+    var photoURL : String
+    var photoComment: String
 }
 
 let testData1 = PhotoCardInformation(imageName: "exampleImage1", photoText: "테스트1")
@@ -77,8 +107,24 @@ struct PhotoCard: View {
     }
 }
 
+struct LoadedPhotoCard: View {
+    var PhotoCardDetail: PhotoGiftData
+    var body: some View {
+        VStack {
+            AsyncImage(url: URL(string: PhotoCardDetail.photoURL))
+                .frame(width: UIScreen.main.bounds.width * 0.35, height: UIScreen.main.bounds.height * 0.2, alignment: .center)
+            
+            Text(PhotoCardDetail.photoComment)
+                .foregroundColor(.bodyTextColor)
+        }
+        .frame(width: UIScreen.main.bounds.width * 0.35, height: UIScreen.main.bounds.height * 0.25, alignment: .center)
+        .padding()
+    }
+}
+
 struct CalendarBaws: PreviewProvider {
     static var previews: some View {
         PhotoCardsView(imageModel: ImageViewModel())
     }
 }
+


### PR DESCRIPTION
## Summary
- PhotoCardsView에서 서버로 부터 저장된 Image 데이터를 Get하는 코드가 추가되었습니다.

## Changes
- AsyncImage를 사용해서 서버로 부터 받아온 Image의 URL을 사용하여 View에 이미지를 만들 수 있습니다.
<img width="827" alt="image" src="https://user-images.githubusercontent.com/103009135/174072743-775bbbbe-02be-41bb-bd08-c4b746871e18.png">

- 기존 Moya 코드에 ImageGet 케이스와 그에 관련된 코드들이 추가되었습니다.
<img width="527" alt="image" src="https://user-images.githubusercontent.com/103009135/174073112-65dde1a3-d6f3-40ef-992b-b755da796448.png">

## Discussion
- 서버에 이미지를 저장하고 받아오는 형식으로 URL을 사용하는데, 이것이 효율적(속도, 용량관리) 방법인지 잘 모르겠습니다.
- 서버 통신에서 동기/비동기 방식의 특징을 더 공부해볼 필요가 있습니다.